### PR TITLE
Corrected bug where the hostname is always reset

### DIFF
--- a/maas_instance.go
+++ b/maas_instance.go
@@ -165,12 +165,14 @@ func resourceMAASInstanceDelete(d *schema.ResourceData, meta interface{}) error 
 			"[ERROR] [resourceMAASInstanceCreate] Error waiting for instance (%s) to become ready: %s", d.Id(), err)
 	}
 
-	params := url.Values{}
-	params.Set("hostname", "")
-	// remove custom hostname
-	err := nodeUpdate(meta.(*Config).MAASObject, d.Id(), params)
-	if err != nil {
-		log.Println("[DEBUG] Unable to update node")
+	// remove deploy hostname if set
+	if _, ok := d.GetOk("deploy_hostname"); ok {
+		params := url.Values{}
+		params.Set("hostname", "")
+		err := nodeUpdate(meta.(*Config).MAASObject, d.Id(), params)
+		if err != nil {
+			log.Println("[DEBUG] Unable to reset hostname: %s", err)
+		}
 	}
 
 	// remove deployed tags


### PR DESCRIPTION
The provider offers the ability to use `deploy_hostname` to set the hostname post deploy. Upon releasing a node it would always reset the node hostname back to a default random name. There was a bug where it would always reset the hostname even if `deploy_hostname` was not used. This patch corrects the bug to only reset the hostname if a `deploy_hostname` was used.